### PR TITLE
change to 10_nwis_pull so partitions don't cause a rebuild

### DIFF
--- a/10_nwis_pull.yml
+++ b/10_nwis_pull.yml
@@ -22,6 +22,12 @@ targets:
       
 # -- get a CONUS inventory of available data for download -- #
 
+  # Edit this to be the current day (YYMMDD) if you want to force a 
+  #   re-download of the data even if the inventory hasn't changed OR
+  #   if you are forcing an entire rebuild, including the inventory.
+  pull_id:
+    command: c(I("200602"))
+
   # modify end date to extend data pull
   nwis_pull_parameters:
     command: yaml.load_file('10_nwis_pull/cfg/nwis_pull_params.yml')
@@ -68,11 +74,11 @@ targets:
   # -- partition data -- #
   # dv
   nwis_dv_partition:
-    command: partition_inventory(inventory = nwis_dv_inventory, nwis_pull_size) 
+    command: partition_inventory(inventory = nwis_dv_inventory, nwis_pull_size, pull_id) 
     
   #uv
   nwis_uv_partition:
-    command: partition_inventory(inventory = nwis_uv_inventory_reduced, nwis_pull_size) 
+    command: partition_inventory(inventory = nwis_uv_inventory_reduced, nwis_pull_size, pull_id) 
     
   # -- create and execute tasks from pull table -- #
 

--- a/10_nwis_pull.yml
+++ b/10_nwis_pull.yml
@@ -25,8 +25,10 @@ targets:
   # Edit this to be the current day (YYMMDD) if you want to force a 
   #   re-download of the data even if the inventory hasn't changed OR
   #   if you are forcing an entire rebuild, including the inventory.
-  pull_id:
+  pull_id_dv:
     command: c(I("200602"))
+  pull_id_uv:
+    command: c(I("200603"))
 
   # modify end date to extend data pull
   nwis_pull_parameters:
@@ -74,11 +76,11 @@ targets:
   # -- partition data -- #
   # dv
   nwis_dv_partition:
-    command: partition_inventory(inventory = nwis_dv_inventory, nwis_pull_size, pull_id) 
+    command: partition_inventory(inventory = nwis_dv_inventory, nwis_pull_size, pull_id_dv) 
     
   #uv
   nwis_uv_partition:
-    command: partition_inventory(inventory = nwis_uv_inventory_reduced, nwis_pull_size, pull_id) 
+    command: partition_inventory(inventory = nwis_uv_inventory_reduced, nwis_pull_size, pull_id_uv) 
     
   # -- create and execute tasks from pull table -- #
 

--- a/10_nwis_pull/src/nwis_partition.R
+++ b/10_nwis_pull/src/nwis_partition.R
@@ -1,4 +1,4 @@
-partition_inventory <- function(inventory, nwis_pull_size) {
+partition_inventory <- function(inventory, nwis_pull_size, pull_id) {
   
   # uv data count number is the number of days between the min and max observation days
   # assume that each day has 15 minute data, which is 96 obs/day
@@ -45,9 +45,7 @@ partition_inventory <- function(inventory, nwis_pull_size) {
   # Prepare one data_frame containing info about each site, including
   # the pull, constituent, and task name (where task name will become the core
   # of the filename)
-  pull_time <- Sys.time()
-  attr(pull_time, 'tzone') <- 'UTC'
-  pull_id <- format(pull_time, '%y%m%d')
+  pull_time <- as.Date(pull_id, '%y%m%d')
 
   partitions <- atomic_groups %>%
     mutate(PullDate = format(pull_time, '%Y-%m-%d'),


### PR DESCRIPTION
The way that we had set up `nwis_dv_partition` and `nwis_uv_partition` is that the partitions are named using the current day's date. Within `partition_inventory`, we used `Sys.time()` to figure out the partition ids. The major problem with this is that the partitions are objects and not files in the yml, so every person will need to build them when they run the pipeline. Even if there are no other changes but the person is building the pipeline on a different day than the original person, the partition ids will now be different and force a rebuild of the WHOLE PIPELINE. This is obviously not an ideal situation. So, the following was one way to avoid rebuilds now and the future unless the inventory is forced to rebuild or the new `pull_id_dv` or `pull_id_uv` targets are changed.

Why `pull_id_dv` and `pull_id_uv` you ask? Well, the first time this pipeline was run all the way through, the dv and uv partition targets were built on different days and thus had different partition ids due to the presence of `Sys.time()` (explained above). So, we implemented this solution with short-term convenience in mind - prevent others from rebuilding this big pull right now due to partition ID naming differences. In the future (before the next big pull), we can consider simplifying this. 

After making this change, I tested that the pipeline would rebuild the partitions but then bypass all the others which were recently built. 

```
library(scipiper)
scmake("nwis_dv_pull_plan")

scmake("nwis_dv_pull_plan")
Starting build at 2020-06-12 14:59:38
<  MAKE > nwis_dv_pull_plan
[ BUILD ] pull_id                                                 |  pull_id <- c("200602")
[  READ ]                                                         |  # loading packages
[    OK ] nwis_pull_size
[    OK ] nwis_pull_parameters
[    OK ] 10_nwis_pull/inout/nwis_dv_inventory.rds.ind
[    OK ] 10_nwis_pull/inout/nwis_dv_inventory.rds
[    OK ] nwis_dv_inventory
[ BUILD ] nwis_dv_partition                                       |  nwis_dv_partition <- partition_inventory(inventory = nwis_dv_in...
[    OK ] nwis_dv_pull_plan
Finished build at 2020-06-12 14:59:50
```