### PR TITLE
Update `tmp` file formats from `RDS` to something faster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.feather
 *.Feather
 *.Rdata
+*.qs
 .httr-oauth
 
 # remake

--- a/10_nwis_pull/src/nwis_combine_functions.R
+++ b/10_nwis_pull/src/nwis_combine_functions.R
@@ -2,12 +2,12 @@
 # .ind file that we will want to share because it represents the shared cache
 combine_nwis_data <- function(ind_file, ...){
   
-  rds_files <- c(...)
+  qs_files <- c(...)
   df_list <- list()
   message('reading in partition files...')
-  for (i in seq_len(length(rds_files))){
+  for (i in seq_len(length(qs_files))){
     print(rds_files[i])
-    flow_dat <- readRDS(rds_files[i]) 
+    flow_dat <- qs::qread(qs_files[i]) 
     
     reduced_dat <- convert_to_long(flow_dat)
     

--- a/10_nwis_pull/src/nwis_combine_functions.R
+++ b/10_nwis_pull/src/nwis_combine_functions.R
@@ -6,7 +6,7 @@ combine_nwis_data <- function(ind_file, ...){
   df_list <- list()
   message('reading in partition files...')
   for (i in seq_len(length(qs_files))){
-    print(rds_files[i])
+    print(qs_files[i])
     flow_dat <- qs::qread(qs_files[i]) 
     
     reduced_dat <- convert_to_long(flow_dat)

--- a/10_nwis_pull/src/nwis_pull.R
+++ b/10_nwis_pull/src/nwis_pull.R
@@ -23,7 +23,7 @@ plan_nwis_pull <- function(partitions, service) {
   download <- scipiper::create_task_step(
     step_name = 'download',
     target_name = function(task_name, step_name, ...) {
-      file.path(folders$tmp, sprintf('%s_%s.rds', service, task_name))
+      file.path(folders$tmp, sprintf('%s_%s.qs', service, task_name))
     },
     command = function(steps, ...) {
       paste(
@@ -55,7 +55,7 @@ create_nwis_pull_makefile <- function(makefile, task_plan, final_targets) {
     makefile=makefile, task_plan=task_plan,
     include = c('10_nwis_pull.yml'),
     sources = c('10_nwis_pull/src/nwis_pull.R', '10_nwis_pull/src/nwis_combine_functions.R'),
-    packages=c('dplyr', 'dataRetrieval', 'scipiper', 'yaml', 'stringr'),
+    packages=c('dplyr', 'dataRetrieval', 'scipiper', 'yaml', 'stringr', 'qs'),
     file_extensions=c('ind'), finalize_funs = 'combine_nwis_data', final_targets = final_targets)
 }
 
@@ -108,10 +108,10 @@ get_nwis_data <- function(data_file, partition, nwis_pull_params, service, verbo
   # NULL (if there are no results)
   nwis_dat <- as_tibble(nwis_dat)
   
-  # write the data to rds file. do this even if there were 0
+  # write the data to `qs` file. do this even if there were 0
   # results because remake expects this function to always create the target
   # file
-  saveRDS(nwis_dat, data_file)
+  qs::qsave(nwis_dat, data_file)
 }
 
 # For UV, sometimes the pull can get stuck on a particular site


### PR DESCRIPTION
This PR closes #16. I chose to convert the temporary files generated by the data pull partitions from `RDS` (in `10_nwis_pull/tmp`) to `qs` as suggested in the original issue.

I tagged @wdwatkins  for the review for two reasons:
 - he opened #16 
 - he was the last one to work on the pipeline

David, please let me know if I should tag someone else for review!


I have also included test code to verify that the process runs as expected:
```r
library(scipiper)
options(scipiper.dry_put = T)
source('10_nwis_pull/src/nwis_combine_functions.R')

# start to build the intermediate tmp files if you don't have them locally by rebuilding the '10_nwis_pull/tmp/nwis_dv_data.rds.ind' target
# manually break after a few dv files have been generated in `10_nwis_pull/tmp`
scmake('10_nwis_pull/tmp/nwis_dv_data.rds.ind') 

# create a list of files to combine
test_combine_files <- list.files('10_nwis_pull/tmp', full.names = T) %>% .[grep('*.qs', .)]

# combine and save locally
combine_nwis_data('10_nwis_pull/tmp/nwis_dv_data_tmp.rds.ind', test_combine_files)

# inspect results
check_results <- readRDS('10_nwis_pull/tmp/nwis_dv_data_tmp.rds')
```

