### PR TITLE
add HUC 22 for AS, GU, MP

### DIFF
--- a/10_nwis_pull/src/inventory_nwis.R
+++ b/10_nwis_pull/src/inventory_nwis.R
@@ -1,6 +1,6 @@
 inventory_nwis <- function(inv_ind, nwis_pull_params, service) {
   
-  hucs <- stringr::str_pad(1:21, width = 2, pad = "0")
+  hucs <- stringr::str_pad(1:22, width = 2, pad = "0")
   nwis_pull_params$service <- service
   nwis_pull_params$statCd <- '00003'
   


### PR DESCRIPTION
In a surprising turn of events, it turns out that American Samoa, Guam, and the Northern Marianas **_do_** have a HUC code - it's "22". Our own documentation on this surprise is not consistent:
 - [USGS water.usgs.gov documentation](https://water.usgs.gov/GIS/huc_name.html#Region21) at indicates that there are only 21 HUCs
 - [USGS NHD documentation](https://nhd.usgs.gov/userGuide/Robohelpfiles/NHD_User_Guide/Feature_Catalog/Watershed_Boundary_Dataset/Watershed_Boundary_Dataset.htm) indicates that there are 22 HUCs

To dig into these inconsistencies a bit I have a snippet of code:
```r
> library(dataRetrieval)
> library(dplyr)
> 
> us_terr <- c('AS', 'GU', 'MP')
> 
> # query by state code
> inv_stateCd <- lapply(us_terr, function(x){
+   whatNWISdata(stateCd = x, statCd = '00003', 
+                parameterCd = '00060', service = 'dv')
+ }) %>% 
+   bind_rows
>                                                                                                                                                                                           
> # query by HUC
> inv_huc <- whatNWISdata(huc = '22', statCd = '00003', 
+                         parameterCd = '00060', service = 'dv') %>% 
+   mutate(method = 'huc')
>                                                                                                                                                                                           
> # investigate stations not returned by both queries
> left_join(inv_stateCd, inv_huc) %>% 
+   filter(is.na(method)) %>% 
+   select(c(1:6, 7, 14, 22:25))
Joining, by = c("agency_cd", "site_no", "station_nm", "site_tp_cd", "dec_lat_va", "dec_long_va", "coord_acy_cd", "dec_coord_datum_cd", "alt_va", "alt_acy_va", "alt_datum_cd", "huc_cd", "data_type_cd", "parm_cd", "stat_cd", "ts_id", "loc_web_ds", "medium_grp_cd", "parm_grp_cd", "srs_id", "access_cd", "begin_date", "end_date", "count_nu")
  agency_cd         site_no                     station_nm site_tp_cd dec_lat_va dec_long_va coord_acy_cd parm_cd begin_date   end_date count_nu method
1      USGS 140733145105901 Matan Hanom Spring, Rota, CNMI         SP   14.12722    145.1855            S   00060 2000-06-08 2001-08-16      435   <NA>
2      USGS        16806000       Lupug Spring, Rota, CNMI         SP   14.12417    145.1894            S   00060 1902-07-17 1975-07-18     1413   <NA>
```

There are two sites that are missed when we query by `HUC` rather than `stateCd`, they have the following characteristics:
 - located in the Northern Marianas
 - Site Type == spring
 - Data is >= 20 years old

I would assume that we would probably miss some NWIS sites the CONUS + AK + HI + Caribbean regions if we did the same `HUC` vs `stateCd` comparison. I did not test this theory because creating the inventory for CONUS + AK + HI + Caribbean was running slowly for me (> 30 min). Because of this assumption, I have decided to keep the query method consistent for all regions.

I am tagging @limnoliver  for this review because this is more of a overall "methods" PR rather than an in depth pipeline review.



Closes #19