### PR TITLE
update dummy dates for 2022 pull

### DIFF
--- a/10_nwis_pull.yml
+++ b/10_nwis_pull.yml
@@ -27,9 +27,9 @@ targets:
   #   re-download of the data even if the inventory hasn't changed OR
   #   if you are forcing an entire rebuild, including the inventory.
   pull_id_dv:
-    command: c(I("210422"))
+    command: c(I("220317"))
   pull_id_uv:
-    command: c(I("210422"))
+    command: c(I("220317"))
 
   # modify end date to extend data pull
   nwis_pull_parameters:


### PR DESCRIPTION
Updating dummy dates in `10_nwis_pull.yml` in preparation for 2022 run.